### PR TITLE
Add retries to lock

### DIFF
--- a/scripts/common/prereqs.sh
+++ b/scripts/common/prereqs.sh
@@ -36,19 +36,31 @@ lvm2"
   if [ ! -z "${packages_to_install}" ]; then
     # attempt to install, probably won't work airgapped but we'll get an error immediately
     echo "Attempting to install: ${packages_to_install} ..."
+    retries=20
     sudo apt-get update
-    while [ $? -ne 0 ]; do
+    while [ $? -ne 0 -a "$retries" -gt 0 ]; do
+      retries=$((retries-1))
       echo "Another process has acquired the apt-get update lock; waiting 10s" 1>&2
       sleep 10;
       sudo apt-get update
     done
+    if [ $? -ne 0 -a "$retries" -eq 0 ] ; then
+      echo "Maximum number of retries (20) for apt-get update attempted; quitting" 1>&2
+      exit 1
+    fi
 
+    retries=20
     sudo apt-get install -y ${packages_to_install}
-    while [ $? -ne 0 ]; do
-      echo "Another process has acquired the apt-get install/upgrade; waiting 10s" 1>&2
+    while [ $? -ne 0 -a "$retries" -gt 0 ]; do
+      retries=$((retries-1))
+      echo "Another process has acquired the apt-get install/upgrade lock; waiting 10s" 1>&2
       sleep 10;
       sudo apt-get install -y ${packages_to_install}
     done
+    if [ $? -ne 0 -a "$retries" -eq 0 ] ; then
+      echo "Maximum number of retries (20) for apt-get install attempted; quitting" 1>&2
+      exit 1
+    fi
   fi
 }
 

--- a/scripts/common/prereqs.sh
+++ b/scripts/common/prereqs.sh
@@ -36,18 +36,18 @@ lvm2"
   if [ ! -z "${packages_to_install}" ]; then
     # attempt to install, probably won't work airgapped but we'll get an error immediately
     echo "Attempting to install: ${packages_to_install} ..."
-    flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
+    sudo flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
     while [ $? -ne 0 ]; do
       echo "Another process has f-locked /var/lib/apt/lists/lock" 1>&2
       sleep 10;
-      flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
+      sudo flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
     done
 
-    flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
+    sudo flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
     while [ $? -ne 0 ]; do
       echo "Another process has f-locked /var/lib/dpkg/lock" 1>&2
       sleep 10;
-      flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
+      sudo flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
     done
   fi
 }

--- a/scripts/common/prereqs.sh
+++ b/scripts/common/prereqs.sh
@@ -36,8 +36,19 @@ lvm2"
   if [ ! -z "${packages_to_install}" ]; then
     # attempt to install, probably won't work airgapped but we'll get an error immediately
     echo "Attempting to install: ${packages_to_install} ..."
-    sudo apt-get update
-    sudo apt-get install -y ${packages_to_install}
+    flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
+    while [ $? -ne 0 ]; do
+      echo "Another process has f-locked /var/lib/apt/lists/lock" 1>&2
+      sleep 10;
+      flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
+    done
+
+    flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
+    while [ $? -ne 0 ]; do
+      echo "Another process has f-locked /var/lib/dpkg/lock" 1>&2
+      sleep 10;
+      flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
+    done
   fi
 }
 

--- a/scripts/common/prereqs.sh
+++ b/scripts/common/prereqs.sh
@@ -36,18 +36,18 @@ lvm2"
   if [ ! -z "${packages_to_install}" ]; then
     # attempt to install, probably won't work airgapped but we'll get an error immediately
     echo "Attempting to install: ${packages_to_install} ..."
-    sudo flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
+    sudo apt-get update
     while [ $? -ne 0 ]; do
-      echo "Another process has f-locked /var/lib/apt/lists/lock" 1>&2
+      echo "Another process has acquired the apt-get update lock; waiting 10s" 1>&2
       sleep 10;
-      sudo flock --timeout 60 --exclusive --close /var/lib/apt/lists/lock apt-get -y -o Dpkg::Options::="--force-confold" update
+      sudo apt-get update
     done
 
-    sudo flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
+    sudo apt-get install -y ${packages_to_install}
     while [ $? -ne 0 ]; do
-      echo "Another process has f-locked /var/lib/dpkg/lock" 1>&2
+      echo "Another process has acquired the apt-get install/upgrade; waiting 10s" 1>&2
       sleep 10;
-      sudo flock --timeout 60 --exclusive --close /var/lib/dpkg/lock apt-get -y -o Dpkg::Options::="--force-confold" install ${packages_to_install}
+      sudo apt-get install -y ${packages_to_install}
     done
   fi
 }


### PR DESCRIPTION
Prevent the retries from continuing indefinitely by capping at 20. This corresponds to a maximum wait time of 100 seconds (1.67 minutes).