### PR TITLE
Support for CentOS and RHEL in this version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ To avoid breaking existing templates which depends on the module it is recommend
 
 
 ### Versions and changes
+#### 2.4.2
+- Added support to be able to deploy ICP 3.1.1 on RedHat and CentOS. (Tested only on ICP 3.1.1-CE with CentOS 7)
+
+#### 2.4.1
+- Added missed prereq in the main.tf file
+
 #### 2.4.0
 - Add support for local hooks
 - Support specifying docker version when installing docker with apt (Ubuntu only)


### PR DESCRIPTION
Implement support for RHEL 7.6 and CentOS so the Terraform script can use this version.

This is needed to be able to get ICP Terraform script working for VMware.

This solve issue #32 