### PR TITLE
fix local hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If the default SSH user is not the root user, the default user must have passwor
 |icp_priv_key        |               |No      |Private ssh key for ICP Boot master to connect to ICP Cluster. Only use when generate_key = false|
 | **Terraform installation process** |
 |hooks               | |No      |Hooks into different stages in the cluster setup process. See below for details|
+|local-hooks         | |No      |Locally run hooks at different stages in the cluster setup process. See below for details|
 |on_hook_failure     |fail  |    |Behavior when hooks fail. Anything other than `fail` will `continue`|
 |install-verbosity   | |No      | Verbosity of the icp ansible installer. -v to -vvvv. See ansible documentation for verbosity information |
 | **Terraform to cluster ssh configuration**|
@@ -72,7 +73,7 @@ So for exmaple
 
 ### Remote Execution Hooks
 It is possible to execute arbitrary commands between various phases of the cluster setup and installation process.
-Currently, the following hooks are defined
+Currently, the following hooks are defined. Each hook must be a list of commands to run.
 
 | Hook name          | Where executed | When executed                                              |
 |--------------------|----------------|------------------------------------------------------------|
@@ -84,7 +85,7 @@ Currently, the following hooks are defined
 
 ### Local Execution Hooks
 It is possible to execute arbitrary commands between various phases of the cluster setup and installation process.
-Currently, the following hooks are defined
+Currently, the following hooks are defined. Each hook must be a single command to run.
 
 | Hook name          | When executed                                              |
 |--------------------|------------------------------------------------------------|

--- a/hooks.tf
+++ b/hooks.tf
@@ -186,7 +186,7 @@ resource "null_resource" "local-preinstall-hook-stop-on-fail" {
   count = "${var.on_hook_failure == "fail" ? 1 : 0}"
 
   provisioner "local-exec" {
-    command = "${var.hooks["local-preinstall"]}"
+    command = "${var.local-hooks["local-preinstall"]}"
     on_failure = "fail"
   }
 }
@@ -195,7 +195,7 @@ resource "null_resource" "local-preinstall-hook-continue-on-fail" {
   count = "${var.on_hook_failure != "fail" ? 1 : 0}"
 
   provisioner "local-exec" {
-    command = "${var.hooks["local-preinstall"]}"
+    command = "${var.local-hooks["local-preinstall"]}"
     on_failure = "continue"
   }
 }
@@ -207,7 +207,7 @@ resource "null_resource" "local-postinstall-hook-stop-on-fail" {
   count = "${var.on_hook_failure == "fail" ? 1 : 0}"
 
   provisioner "local-exec" {
-    command = "${var.hooks["local-postinstall"]}"
+    command = "${var.local-hooks["local-postinstall"]}"
     on_failure = "fail"
   }
 }
@@ -216,7 +216,7 @@ resource "null_resource" "local-postinstall-hook-continue-on-fail" {
   count = "${var.on_hook_failure != "fail" ? 1 : 0}"
 
   provisioner "local-exec" {
-    command = "${var.hooks["local-postinstall"]}"
+    command = "${var.local-hooks["local-postinstall"]}"
     on_failure = "continue"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -119,15 +119,23 @@ variable "config_strategy" {
 
 }
 
+
 variable "hooks" {
-  description = "Hooks into different stages in the cluster setup process"
+  description = "Hooks into different stages in the cluster setup process; each must be a list"
   type        = "map"
   default     = {
-    cluster-preconfig  = "echo -n"
-    cluster-postconfig = "echo -n"
-    boot-preconfig     = "echo -n"
-    preinstall         = "echo -n"
-    postinstall        = "echo -n"
+    cluster-preconfig  = "[echo -n]"
+    cluster-postconfig = "[echo -n]"
+    boot-preconfig     = "[echo -n]"
+    preinstall         = "[echo -n]"
+    postinstall        = "[echo -n]"
+  }
+}
+
+variable "local-hooks" {
+  description = "Local hooks into different stages in the cluster setup process; each must be a single command"
+  type        = "map"
+  default     = {
     local-preinstall   = "echo -n"
     local-postinstall  = "echo -n"
   }


### PR DESCRIPTION
I was getting the following error when using the icp-deploy module

```
local-preinstall-hook-stop-on-fail: key "local-preinstall" does not exist in map var.hooks in:

${var.hooks["local-preinstall"]}
```

I think it might have been caused by mixing map types, but this seems to have fixed it. The errors do not show up when running `terraform init` from this module, only when trying to use this module from another.