### PR TITLE
Change permissions of cluster directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If the default SSH user is not the root user, the default user must have passwor
 |local-hooks         | |No      |Locally run hooks at different stages in the cluster setup process. See below for details|
 |on_hook_failure     |fail  |    |Behavior when hooks fail. Anything other than `fail` will `continue`|
 |install-verbosity   | |No      | Verbosity of the icp ansible installer. -v to -vvvv. See ansible documentation for verbosity information |
+|cluster_dir_owner   |               |No      |Username to own cluster directory after an install. Defaults to `ssh_user`|
 | **Terraform to cluster ssh configuration**|
 |ssh_user            |root           |No      |Username for Terraform to ssh into the ICP cluster. This is typically the default user with for the relevant cloud vendor|
 |ssh_key_base64      |               |No      |base64 encoded content of private ssh key|
@@ -302,6 +303,9 @@ To avoid breaking existing templates which depends on the module it is recommend
 
 
 ### Versions and changes
+- Fix issues when owner of cluster files are something other than `ssh_user`
+- Allow the cluster directory to be owned by arbitrary user after install
+
 #### 3.0.8
 - Fix docker install from yum repo for non-root user on RHEL
 

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ resource "null_resource" "icp-docker" {
     inline = [
       "mkdir -p /tmp/icp-bootmaster-scripts",
       "sudo mkdir -p /opt/ibm/cluster",
+      "sudo chown ${var.ssh_user} /opt/ibm",
       "sudo chown ${var.ssh_user} /opt/ibm/cluster"
     ]
   }

--- a/main.tf
+++ b/main.tf
@@ -291,7 +291,9 @@ resource "null_resource" "icp-worker-scaler" {
   provisioner "remote-exec" {
     inline = [
       "chmod a+x /tmp/icp-bootmaster-scripts/scaleworkers.sh",
+      "sudo chown ${var.ssh_user}:${var.ssh_user} -R /opt/ibm/cluster/",
       "/tmp/icp-bootmaster-scripts/scaleworkers.sh ${var.icp-inception}"
+      "sudo chown ${local.cluster_dir_owner}:${local.cluster_dir_owner} -R /opt/ibm/cluster/",
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -168,7 +168,6 @@ resource "null_resource" "icp-config" {
   provisioner "remote-exec" {
     inline = [
       "/tmp/icp-bootmaster-scripts/copy_cluster_skel.sh ${var.icp-inception == "" ? "" : " -v ${var.icp-inception}"}",
-      "sudo chown ${var.ssh_user} /opt/ibm/cluster/*",
       "chmod 600 /opt/ibm/cluster/ssh_key",
       "python /tmp/icp-bootmaster-scripts/load-config.py ${var.config_strategy} ${random_string.generated_password.result}"
     ]

--- a/main.tf
+++ b/main.tf
@@ -74,8 +74,7 @@ resource "null_resource" "icp-docker" {
     inline = [
       "mkdir -p /tmp/icp-bootmaster-scripts",
       "sudo mkdir -p /opt/ibm/cluster",
-      "sudo chown ${var.ssh_user} /opt/ibm",
-      "sudo chown ${var.ssh_user} /opt/ibm/cluster"
+      "sudo chown -R ${var.ssh_user} /opt/ibm"
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -295,7 +295,23 @@ resource "null_resource" "icp-worker-scaler" {
       "/tmp/icp-bootmaster-scripts/scaleworkers.sh ${var.icp-inception}"
     ]
   }
+}
 
+resource "null_resource" "icp-cluster-owner" {
+  depends_on = ["null_resource.icp-worker-scaler", "null_resource.icp-postinstall-hook-continue-on-fail", "null_resource.icp-postinstall-hook-stop-on-fail"]
 
+  # Change the owner of the cluster directory to the desired user
+  connection {
+    host          = "${local.boot-node}"
+    user          = "${var.ssh_user}"
+    private_key   = "${local.ssh_key}"
+    agent         = "${var.ssh_agent}"
+    bastion_host  = "${var.bastion_host}"
+  }
 
+  provisioner "remote-exec" {
+    inline = [
+      "sudo chown ${local.cluster_dir_owner}:${local.cluster_dir_owner} -R /opt/ibm/cluster/",
+    ]
+  }
 }

--- a/scripts/boot-master/copy_cluster_skel.sh
+++ b/scripts/boot-master/copy_cluster_skel.sh
@@ -33,6 +33,8 @@ echo "registry=${registry:-not specified} org=$org repo=$repo tag=$tag"
 sudo mkdir -p ${target}
 sudo chown $(whoami):$(whoami) -R ${target}
 docker run -e LICENSE=accept -v ${target}:/data ${registry}${registry:+/}${org}/${repo}:${tag} cp -r cluster /data
+# Ensure that all data copied from installer has proper ownership
+sudo chown $(whoami):$(whoami) -R ${target}
 
 # Take a backup of original config file, to keep a record of original settings and comments
 cp ${target}/cluster/config.yaml ${target}/cluster/config.yaml-original

--- a/scripts/boot-master/load-image.sh
+++ b/scripts/boot-master/load-image.sh
@@ -45,7 +45,8 @@ parse_icpversion ${image}
 echo "registry=${registry:-not specified} org=$org repo=$repo tag=$tag"
 
 # Make sure sourcedir exists, in case we need to donwload some archives
-mkdir -p ${sourcedir}
+sudo mkdir -p ${sourcedir}
+sudo chown $(whoami):$(whoami) ${sourcedir}
 
 if [[ ! -z ${image} ]]; then
   # Figure out the version

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,11 @@ variable "ssh_user" {
   default     = "root"
 }
 
+variable "cluster_dir_owner" {
+  description = "Username to own the ICP cluster directory after installation completes; defaults to ssh_user"
+  default     = ""
+}
+
 variable "ssh_key_base64" {
   description = "base64 encoded content of private ssh key"
   default     = ""
@@ -179,4 +184,6 @@ locals {
   cluster_size  = "${length(concat(var.icp-master, var.icp-proxy, var.icp-worker, var.icp-management))}"
   ssh_key       = "${base64decode(var.ssh_key_base64)}"
   boot-node     = "${element(compact(concat(list(var.boot-node),var.icp-master)), 0)}"
+
+  cluster_dir_owner = "${var.cluster_dir_owner == "" ? var.ssh_user : var.cluster_dir_owner}"
 }


### PR DESCRIPTION
- Fix issues when owner of cluster files are something other than `ssh_user`
- Allow the cluster directory to be owned by arbitrary user after install