### PR TITLE
3.1.0 fixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -178,18 +178,19 @@ resource "null_resource" "icp-config" {
   # Copy the provided or generated private key
   provisioner "file" {
       content = "${var.generate_key ? tls_private_key.icpkey.private_key_pem : var.icp_priv_key}"
-      destination = "${var.cluster-directory}/ssh_key"
+      destination = "/tmp/icp/cluster/ssh_key"
   }
 
   # Since the file provisioner deals badly with empty lists, we'll create the optional management nodes differently
   # Later we may refactor to use this method for all node types for consistency
   provisioner "remote-exec" {
     inline = [
-      "chmod 600 ${var.cluster-directory}/cluster/ssh_key",
-      "echo -n ${join(",", var.icp-master)} > ${var.cluster-directory}/masterlist.txt",
-      "echo -n ${join(",", var.icp-proxy)} > ${var.cluster-directory}/proxylist.txt",
-      "echo -n ${join(",", var.icp-worker)} > ${var.cluster-directory}/workerlist.txt",
-      "echo -n ${join(",", var.icp-management)} > ${var.cluster-directory}/managementlist.txt"
+      "echo -n ${join(",", var.icp-master)} > /tmp/icp/cluster/masterlist.txt",
+      "echo -n ${join(",", var.icp-proxy)} > /tmp/icp/cluster/proxylist.txt",
+      "echo -n ${join(",", var.icp-worker)} > /tmp/icp/cluster/workerlist.txt",
+      "echo -n ${join(",", var.icp-management)} > /tmp/icp/cluster/managementlist.txt",
+      "mv -f /tmp/icp/cluster/* ${var.cluster-directory}/",
+      "chmod 600 ${var.cluster-directory}/ssh_key"
     ]
   }
 
@@ -217,7 +218,7 @@ resource "null_resource" "icp-generate-hosts-files" {
 
   provisioner "remote-exec" {
     inline = [
-      "/tmp/icp-bootmaster-scripts/generate_hostsfiles.sh"
+      "/tmp/icp-bootmaster-scripts/generate_hostsfiles.sh ${local.script_options}"
     ]
   }
 }

--- a/scripts/boot-master/copy_cluster_skel.sh
+++ b/scripts/boot-master/copy_cluster_skel.sh
@@ -20,9 +20,9 @@ echo "registry=${registry:-not specified} org=$org repo=$repo tag=$tag"
 
 # Copy the default data to the cluster directory
 docker run -e LICENSE=accept -v /tmp/icp:/data ${registry}${registry:+/}${org}/${repo}:${tag} cp -r cluster /data
+sudo chown $(whoami):$(whoami) -R /tmp/icp
 ensure_directory_reachable ${cluster_dir}
-sudo cp -rn /tmp/icp/cluster/* ${cluster_dir}
-sudo chown $(whoami):$(whoami) -R ${cluster_dir}
+sudo mv /tmp/icp/cluster/* ${cluster_dir}
 
 # Take a backup of original config file, to keep a record of original settings and comments
 cp ${cluster_dir}/config.yaml ${cluster_dir}/config.yaml-original

--- a/scripts/boot-master/copy_cluster_skel.sh
+++ b/scripts/boot-master/copy_cluster_skel.sh
@@ -21,7 +21,7 @@ echo "registry=${registry:-not specified} org=$org repo=$repo tag=$tag"
 # Copy the default data to the cluster directory
 docker run -e LICENSE=accept -v /tmp/icp:/data ${registry}${registry:+/}${org}/${repo}:${tag} cp -r cluster /data
 ensure_directory_reachable ${cluster_dir}
-sudo mv /tmp/icp/cluster ${cluster_dir}
+sudo cp -rn /tmp/icp/cluster/* ${cluster_dir}
 sudo chown $(whoami):$(whoami) -R ${cluster_dir}
 
 # Take a backup of original config file, to keep a record of original settings and comments

--- a/scripts/boot-master/functions.sh
+++ b/scripts/boot-master/functions.sh
@@ -38,7 +38,7 @@ function parse_icpversion() {
   then
     # We should autodetect the version if loaded from tarball
     # For now we grab the first matching image in docker image list.
-    read -r repo tag <<<$(docker image list | awk -v pat=$DefaultRepo ' $1 ~ pat { print $1 " " $2 ; exit }')
+    read -r repo tag <<<$(sudo docker image list | awk -v pat=$DefaultRepo ' $1 ~ pat { print $1 " " $2 ; exit }')
 
     # As a last resort we'll use the latest tag from docker hub
     if [[ -z $tag ]]; then
@@ -55,7 +55,7 @@ function parse_icpversion() {
 function get_inception_image() {
   # In cases where inception image has not been specified
   # we may look for inception image locally
-  image=$(docker image list | grep -m 1 inception | awk '{ print $1 ":" $2 }')
+  image=$(sudo docker image list | grep -m 1 inception | awk '{ print $1 ":" $2 }')
   echo $image
 }
 

--- a/scripts/boot-master/generate_hostsfiles.sh
+++ b/scripts/boot-master/generate_hostsfiles.sh
@@ -100,7 +100,7 @@ read_from_groupfiles() {
 
 read_from_hostgroups() {
   # First parse the hostgroup json
-  python /tmp/icp-bootmaster-scripts/parse-hostgroups.py
+  python /tmp/icp-bootmaster-scripts/parse-hostgroups.py ${cluster_dir}
 
   # Get the cluster ips
   declare -a cluster_ips

--- a/scripts/boot-master/load-config.py
+++ b/scripts/boot-master/load-config.py
@@ -22,16 +22,15 @@ with open(config_items, 'r') as stream:
 supplied_cluster_dir = ""
 if len(sys.argv) > 1:
   supplied_cluster_dir = sys.argv[1]
-  config_orig = os.path.join(supplied_cluster_dir,"/config.yaml")
+  config_orig = os.path.join(supplied_cluster_dir,"config.yaml")
   if not os.path.exists(config_orig):
     config_orig = None
-
-if config_orig is None:
-    raise Exception("Invalid cluster directory provided: {}".format(supplied_cluster_dir))
 
 # If merging changes, start by loading default values. Else start with empty dict
 if len(sys.argv) > 2:
   if sys.argv[2] == "merge":
+    if config_orig is None:
+        raise Exception("Invalid cluster directory provided: {}\n\tconfig.yaml could not be found.".format(supplied_cluster_dir))
     with open(config_orig, 'r') as stream:
       try:
         config_o = yaml.load(stream)

--- a/scripts/boot-master/load-image.sh
+++ b/scripts/boot-master/load-image.sh
@@ -91,9 +91,7 @@ else
   # If we don't have an image locally we'll pull from docker registry
   if [[ -z $(docker images -q ${registry}${registry:+/}${org}/${repo}:${tag}) ]]; then
     # If this is a private registry we may need to log in
-    if [[ ! -z "$username" ]]; then
-      docker login -u ${username} -p ${password} ${registry}
-    fi
+    [[ ! -z "$username" ]] && [[ ! -z "$password" ]] && docker login -u ${username} -p ${password} ${registry}
     # ${registry}${registry:+/} adds <registry>/ only if registry is specified
     docker pull ${registry}${registry:+/}${org}/${repo}:${tag}
   fi

--- a/scripts/boot-master/parse-hostgroups.py
+++ b/scripts/boot-master/parse-hostgroups.py
@@ -7,7 +7,7 @@ ipfile = '/tmp/cluster-ips.txt'
 supplied_cluster_dir = ""
 if len(sys.argv) > 1:
   supplied_cluster_dir = sys.argv[1]
-  hostfile = os.path.join(supplied_cluster_dir,"/hosts")
+  hostfile = os.path.join(supplied_cluster_dir,"hosts")
   if not os.path.isdir(supplied_cluster_dir):
     hostfile = None
 

--- a/scripts/boot-master/start_install.sh
+++ b/scripts/boot-master/start_install.sh
@@ -2,7 +2,6 @@
 source /tmp/icp-bootmaster-scripts/get-args.sh
 source /tmp/icp-bootmaster-scripts/functions.sh
 
-
 # If loaded from tarball, icp version may not be specified in terraform
 if [[ -z "${icp_version}" ]]; then
   icp_version=$(get_inception_image)
@@ -13,6 +12,6 @@ fi
 parse_icpversion ${icp_version}
 echo "registry=${registry:-not specified} org=$org repo=$repo tag=$tag"
 
-docker run -e LICENSE=accept -e ANSIBLE_CALLBACK_WHITELIST=profile_tasks,timer --net=host -t -v ${cluster_dir}:/installer/cluster ${registry}${registry:+/}${org}/${repo}:${tag} ${install_target} ${log_verbosity} |& tee /tmp/icp-${install_target}-log.txt
+docker run -e LICENSE=accept -e ANSIBLE_CALLBACK_WHITELIST=profile_tasks,timer --net=host -t -v ${cluster_dir}:/installer/cluster ${registry}${registry:+/}${org}/${repo}:${tag} ${install_command} ${log_verbosity} |& tee /tmp/icp-${install_command}-log.txt
 
 exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Fixed the issue

```
module.icpprovision.null_resource.icp-config (remote-exec): cp: cannot stat '/opt/ibm/cluster/config.yaml': No such file or directory
module.icpprovision.null_resource.icp-config (remote-exec): Traceback (most recent call last):
module.icpprovision.null_resource.icp-config (remote-exec):   File "/tmp/icp-bootmaster-scripts/load-config.py", line 30, in <module>
module.icpprovision.null_resource.icp-config (remote-exec):     raise Exception("Invalid cluster directory provided: {}".format(supplied_cluster_dir))
module.icpprovision.null_resource.icp-config (remote-exec): Exception: Invalid cluster directory provided: /opt/ibm/cluster
```

Still working on the next issue 

```
module.icpprovision.null_resource.icp-config: Provisioning with 'file'...
module.icpprovision.null_resource.icp-config: Still creating... (10s elapsed)

Error: Error applying plan:

1 error(s) occurred:

* module.icpprovision.null_resource.icp-config: Upload failed: scp: /opt/ibm/cluster/ssh_key: Permission denied
```