### PR TITLE
Fix issue in scaling up workers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -288,7 +288,7 @@ resource "null_resource" "icp-worker-scaler" {
     inline = [
       "chmod a+x /tmp/icp-bootmaster-scripts/scaleworkers.sh",
       "sudo chown ${var.ssh_user}:${var.ssh_user} -R ${var.cluster-directory}",
-      "/tmp/icp-bootmaster-scripts/scaleworkers.sh ${var.icp-inception}",
+      "/tmp/icp-bootmaster-scripts/scaleworkers.sh ${local.script_options}",
       "sudo chown ${local.cluster_dir_owner}:${local.cluster_dir_owner} -R ${var.cluster-directory}"
     ]
   }

--- a/scripts/boot-master/scaleworkers.sh
+++ b/scripts/boot-master/scaleworkers.sh
@@ -7,7 +7,7 @@ OLDLIST=${cluster_dir}/workerlist.txt
 
 # Figure out the version
 # This will populate $org $repo and $tag
-parse_icpversion ${1}
+parse_icpversion ${icp_inception}
 
 # Compare new and old list of workers
 declare -a newlist
@@ -96,7 +96,7 @@ then
 
   list=$(IFS=, ; echo "${added[*]}")
   docker run -e LICENSE=accept --net=host -v "${cluster_dir}":/installer/cluster \
-  ${registry}${registry:+/}${org}/${repo}:${tag} install -l ${list}
+  ${registry}${registry:+/}${org}/${repo}:${tag} worker -l ${list}
 fi
 
 


### PR DESCRIPTION
Update `main.tf` to invoke `scaleworkers.sh` with common parameters for scripts.

fixes #49 

The commit also includes a fix to the command used with the inception container to add the new worker to the cluster which was encountered when testing the fix. According to https://www.ibm.com/support/knowledgecenter/SSBS6K_3.1.2/installing/add_node.html and prior versions back to at least 2.1.0.3, the correct command is `worker` and not `install`